### PR TITLE
Reestructuración envio del dato

### DIFF
--- a/Prueba/Prueba/ConexionCliente/AddDatoMensaje.cs
+++ b/Prueba/Prueba/ConexionCliente/AddDatoMensaje.cs
@@ -7,12 +7,12 @@ using System.Threading.Tasks;
 
 namespace Prueba.ConexionCliente
 {
-    public class AddSongMensaje : Mensajes
+    public class AddDatoMensaje : Mensajes
     {
         public Canciones cancion { get; set; }
        // public Usuario usuario { get; set; }
 
-        public AddSongMensaje()
+        public AddDatoMensaje()
         {
 
         }

--- a/Prueba/Prueba/ConexionCliente/SocketCliente.cs
+++ b/Prueba/Prueba/ConexionCliente/SocketCliente.cs
@@ -19,62 +19,66 @@ namespace Prueba.TCPCliente
     class SocketCliente
     {
 
-        public SocketCliente()
+        public SocketCliente(AddDatoMensaje mensajeEntrante)
         {
 
             //http://www.srikanthtechnologies.com/blog/java/java_cs_xml.aspx
-           byte[] byteCancion = System.Text.Encoding.UTF8.GetBytes("holiwi");
-            // Canciones cancion = new Canciones("Mana","albumcito","la Song","Metalero","HOLHAOHLAHOAHLAHOAHL", byteCancion[0]);
-            Canciones cancion = new Canciones();
-            cancion.nombreCancion = "Cancion de la hoguera";
-            cancion.artista = "Bob Esponja";
+            /**
+             * El codigo de operacion se asigan al momento de crear el AddDatoMensaje en el metodo seleccionado, aqui solamente invoca la funcion usarSocket
+             */
+                //Enviar el mensaje tipo AddDatoMensaje y listo.
+                usarSocket(mensajeEntrante);
 
-            AddSongMensaje mensaje = new AddSongMensaje();
-            mensaje.OpCod = "01";
-            mensaje.cancion = cancion;
-            mensaje.cancion.PRUEBAA = "212";
-
-            //de object a xml
-
-
-               string ObjectXML = ObjectToXml(mensaje);
-
-            //de xml a object
-            //   Canciones XMLObject = XMLtoObject<Canciones>(ObjectXML);
-            ObjectXML=ObjectXML.Replace("\n", "").Replace("\r", "");
-              Console.WriteLine(ObjectXML.ToString());
-           // Console.WriteLine(XMLObject.nombreCancion);
-           
-
-            //IMPORTANTE
             
-            TcpClient tcpClient = new TcpClient("localhost", 5000);
-             NetworkStream networkStream = tcpClient.GetStream();
-             byte[] datoByte;
-
-             Console.WriteLine();
-            string datoEnviar = ObjectXML;
-              datoByte = Encoding.UTF8.GetBytes(datoEnviar+"\n");
-            //Envia al servidor
-             networkStream.Write(datoByte, 0, datoEnviar.Length + 1);
-           
-            
-            //Importante*
-            
-            
-             //Leer del servidor
-             datoByte = new byte[312];
-             networkStream.Read(datoByte, 0, 312);
-             //El dato que se va a obtener
-             String datorecibido = Encoding.UTF8.GetString(datoByte);
-             //Quita los bytes sobrantes
-             datorecibido = datorecibido.Substring(0, datorecibido.IndexOf(char.ConvertFromUtf32(0)));
-             Console.WriteLine(datorecibido);
-
-
+        
              
 
 
+        }
+
+        private void usarSocket(AddDatoMensaje mensaje)
+        {
+            string ObjectXML = ObjectToXml(mensaje);
+
+            //de xml a object
+            //   Canciones XMLObject = XMLtoObject<Canciones>(ObjectXML);
+            ObjectXML = ObjectXML.Replace("\n", "").Replace("\r", "");
+            Console.WriteLine(ObjectXML.ToString());
+            // Console.WriteLine(XMLObject.nombreCancion);
+
+
+            //IMPORTANTE
+
+            TcpClient tcpClient = new TcpClient("localhost", 5000);
+            NetworkStream networkStream = tcpClient.GetStream();
+            byte[] datoByte;
+
+            Console.WriteLine();
+            string datoEnviar = ObjectXML;
+            datoByte = Encoding.UTF8.GetBytes(datoEnviar + "\n");
+            //Envia al servidor
+            networkStream.Write(datoByte, 0, datoEnviar.Length + 1);
+
+
+   
+            /**AQUI SE DEBE IMPLEMENTAR LO QUE SE VE HACER CON LO QUE HIZO EL SERVER*/
+            //Leer del servidor
+            datoByte = new byte[312];
+            networkStream.Read(datoByte, 0, 312);
+            //El dato que se va a obtener
+            String datorecibido = Encoding.UTF8.GetString(datoByte);
+            //Quita los bytes sobrantes
+            datorecibido = datorecibido.Substring(0, datorecibido.IndexOf(char.ConvertFromUtf32(0)));
+            Console.WriteLine(datorecibido);
+
+        }
+        private AddDatoMensaje mensajeCancion(String codigoOp,Canciones cancion)
+        {
+            AddDatoMensaje mensaje = new AddDatoMensaje();
+            mensaje.OpCod = codigoOp;
+            mensaje.cancion = cancion;
+          //  mensaje.cancion.PRUEBAA = "212";
+            return mensaje;
         }
 
 

--- a/Prueba/Prueba/Form1.cs
+++ b/Prueba/Prueba/Form1.cs
@@ -1,4 +1,5 @@
-﻿using Prueba.TCPCliente;
+﻿using Prueba.ConexionCliente;
+using Prueba.TCPCliente;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -32,18 +33,20 @@ namespace Prueba
                 rutasMP3 = CajaBsuquedaArchivos.FileNames;
                 foreach (var rutaMp3 in rutasMP3)
                 {
-                    byte[] byteCancion = System.IO.File.ReadAllBytes(rutaMp3.ToString());
-                    // Console.WriteLine(byteCancion[0].ToString());
-                    int num = 0;
-                  /*  while (byteCancion[num]!=null)
-                    {
-
-                        Console.WriteLine(byteCancion[num].ToString());
-                        num++;
-                    }   */
-
+                    //Lee los bytes de la cancion
+                    byte[] bytesCancionSelect = System.IO.File.ReadAllBytes(rutaMp3.ToString());
+                 
                 }
-                new SocketCliente();
+                byte[] byteCancion = System.Text.Encoding.UTF8.GetBytes("holiwi");
+                // Canciones cancion = new Canciones("Mana","albumcito","la Song","Metalero","HOLHAOHLAHOAHLAHOAHL", byteCancion[0]);
+                Canciones cancion = new Canciones();
+                cancion.nombreCancion = "Cancion de la hoguera";
+                cancion.artista = "Bob Esponja";
+                AddDatoMensaje mensajeCancion=new AddDatoMensaje();
+                mensajeCancion.cancion = cancion;
+                mensajeCancion.OpCod = "01";
+
+                new SocketCliente(mensajeCancion);
            
            }
 

--- a/Prueba/Prueba/Odyssey Cliente.csproj
+++ b/Prueba/Prueba/Odyssey Cliente.csproj
@@ -45,7 +45,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="ConexionCliente\AddSongMensaje.cs" />
+    <Compile Include="ConexionCliente\AddDatoMensaje.cs" />
     <Compile Include="Form1.cs">
       <SubType>Form</SubType>
     </Compile>


### PR DESCRIPTION
Se cambio el constructor predeterminado, ahora, recibe solamente un objeto tipo addDatoMensaje, e invoca una funcion para enviar el XML. Se debe asignar al momento de crear el objeto a enviar, el tipo de opCod y los objetos que va a contener.